### PR TITLE
Ad7616 zcu102 rebased2

### DIFF
--- a/projects/ad7616_sdz/common/ad7616_bd.tcl
+++ b/projects/ad7616_sdz/common/ad7616_bd.tcl
@@ -77,8 +77,8 @@ ad_cpu_interconnect  0x44A30000 axi_ad7616_dma
 
 # memory interconnect
 
-ad_mem_hp1_interconnect sys_cpu_clk sys_ps7/S_AXI_HP1
-ad_mem_hp1_interconnect sys_cpu_clk axi_ad7616_dma/m_dest_axi
+ad_mem_hpc1_interconnect sys_cpu_clk sys_ps8/S_AXI_HPC1
+ad_mem_hpc1_interconnect sys_cpu_clk axi_ad7616_dma/m_dest_axi
 ad_connect sys_cpu_resetn axi_ad7616_dma/m_dest_axi_aresetn
 
 # interrupts

--- a/projects/ad7616_sdz/common/ad7616_bd.tcl
+++ b/projects/ad7616_sdz/common/ad7616_bd.tcl
@@ -77,8 +77,6 @@ ad_cpu_interconnect  0x44A30000 axi_ad7616_dma
 
 # memory interconnect
 
-ad_mem_hpc1_interconnect sys_cpu_clk sys_ps8/S_AXI_HPC1
-ad_mem_hpc1_interconnect sys_cpu_clk axi_ad7616_dma/m_dest_axi
 ad_connect sys_cpu_resetn axi_ad7616_dma/m_dest_axi_aresetn
 
 # interrupts

--- a/projects/ad7616_sdz/common/ad7616_parallel_fmc.txt
+++ b/projects/ad7616_sdz/common/ad7616_parallel_fmc.txt
@@ -1,0 +1,35 @@
+FMC_pin FMC_port             Schematic_name   System_top_name  IOSTANDARD  Termination
+
+# ad7616 - Parallel mode
+# Note: The design uses an SDP to FMC interposer.
+
+C14     FMC1_LA10_P       DB0              adc_db[0]         LVCOMOS18     #N/A
+H10     FMC1_LA04_P       DB1              adc_db[1]         LVCOMOS18     #N/A
+D14     FMC1_LA09_P       DB2              adc_db[2]         LVCOMOS18     #N/A
+G9      FMC1_LA03_P       DB3              adc_db[3]         LVCOMOS18     #N/A
+D12     FMC1_LA05_N       DB4              adc_db[4]         LVCOMOS18     #N/A
+H8      FMC1_LA02_N       DB5              adc_db[5]         LVCOMOS18     #N/A
+C11     FMC1_LA06_N       DB6              adc_db[6]         LVCOMOS18     #N/A
+G7      FMC1_LA00_CC_N    DB7              adc_db[7]         LVCOMOS18     #N/A
+D11     FMC1_LA05_P       DB8              adc_db[8]         LVCOMOS18     #N/A
+H7      FMC1_LA02_P       DB9              adc_db[9]         LVCOMOS18     #N/A
+C10     FMC1_LA06_P       DB10             adc_db[10]        LVCOMOS18     #N/A
+G6      FMC1_LA00_CC_P    DB11             adc_db[11]        LVCOMOS18     #N/A
+D9      FMC1_LA01_CC_N    DB12             adc_db[12]        LVCOMOS18     #N/A
+H5      FMC1_CLK0_M2C_N   DB13             adc_db[13]        LVCOMOS18     #N/A
+H4      FMC1_CLK0_M2C_P   DB14             adc_db[14]        LVCOMOS18     #N/A
+D8      FMC1_LA01_CC_P    DB15             adc_db[15]        LVCOMOS18     #N/A
+
+G10     FMC1_LA03_N       SCLK/RDn         adc_rd_n          LVCOMOS18     #N/A
+D15     FMC1_LA09_N       WRn              adc_wr_n          LVCOMOS18     #N/A
+
+H28     FMC1_LA24_P       CONVST           adc_cnvst         LVCOMOS18     #N/A
+H26     FMC1_LA21_N       CHSEL0           adc_chsel[0]      LVCOMOS18     #N/A
+D27     FMC1_LA26_N       CHSEL1           adc_chsel[1]      LVCOMOS18     #N/A
+G27     FMC1_LA25_P       CHSEL2           adc_chsel[2]      LVCOMOS18     #N/A
+H25     FMC1_LA21_P       HW_RNGSEL0       adc_hw_rngsel[0]  LVCOMOS18     #N/A
+D26     FMC1_LA26_P       HW_RNGSEL1       adc_hw_rngsel[1]  LVCOMOS18     #N/A
+C15     FMC1_LA10_N       BUSY             adc_busy          LVCOMOS18     #N/A
+C26     FMC1_LA27_P       SEQEN            adc_seq_en        LVCOMOS18     #N/A
+G25     FMC1_LA22_N       RESETn           adc_reset_n       LVCOMOS18     #N/A
+H11     FMC1_LA04_N       CSn              adc_cs_n          LVCOMOS18     #N/A

--- a/projects/ad7616_sdz/common/ad7616_serial_fmc.txt
+++ b/projects/ad7616_sdz/common/ad7616_serial_fmc.txt
@@ -1,0 +1,26 @@
+FMC_pin FMC_port             Schematic_name   System_top_name   IOSTANDARD  Termination
+
+# ad7616 - Serial mode
+# Note: The design uses an SDP to FMC interposer.
+
+G10    FMC1_LA03_N       SCLK/RDn         spi_sclk   LVCOMOS18     #N/A
+G9     FMC1_LA03_P       DB3              spi_sdo    LVCOMOS18     #N/A
+G6     FMC1_LA00_CC_P    DB11/DOUT0       spi_sdi[0] LVCOMOS18     #N/A
+D9     FMC1_LA01_CC_N    DB7              spi_sdi[1] LVCOMOS18     #N/A
+H11    FMC1_LA04_N       CSn              spi_cs     LVCOMOS18     #N/A
+
+H28    FMC1_LA24_P       CONVST           adc_cnvst         LVCOMOS18     #N/A
+H26    FMC1_LA21_N       CHSEL0           adc_chsel[0]      LVCOMOS18     #N/A
+D27    FMC1_LA26_N       CHSEL1           adc_chsel[1]      LVCOMOS18     #N/A
+G27    FMC1_LA25_P       CHSEL2           adc_chsel[2]       LVCOMOS18     #N/A
+H25    FMC1_LA21_P       HW_RNGSEL0       adc_hw_rngsel[0]  LVCOMOS18     #N/A
+D26    FMC1_LA26_P       HW_RNGSEL1       adc_hw_rngsel[1]  LVCOMOS18     #N/A
+C15    FMC1_LA10_N       BUSY             adc_busy          LVCOMOS18     #N/A
+C26    FMC1_LA27_P       SEQEN            adc_seq_en        LVCOMOS18     #N/A
+G25    FMC1_LA22_N       RESETn           adc_reset_n       LVCOMOS18     #N/A
+
+H5     FMC1_CLK0_M2C_N   DB13             adc_os[0]         LVCOMOS18     #N/A
+H4     FMC1_CLK0_M2C_P   DB14             adc_os[1]         LVCOMOS18     #N/A
+D8     FMC1_LA01_CC_P    DB15             adc_os[2]         LVCOMOS18     #N/A
+D15    FMC1_LA09_N       WRn              adc_burst         LVCOMOS18     #N/A
+H8     FMC1_LA02_N       DB5              adc_crcen         LVCOMOS18     #N/A

--- a/projects/ad7616_sdz/zc706/system_bd.tcl
+++ b/projects/ad7616_sdz/zc706/system_bd.tcl
@@ -17,3 +17,7 @@ sysid_gen_sys_init_file
 
 source ../common/ad7616_bd.tcl
 
+# memory interconnect
+
+ad_mem_hp1_interconnect sys_cpu_clk sys_ps7/S_AXI_HPC1
+ad_mem_hp1_interconnect sys_cpu_clk axi_ad7616_dma/m_dest_axi

--- a/projects/ad7616_sdz/zc706/system_project.tcl
+++ b/projects/ad7616_sdz/zc706/system_project.tcl
@@ -23,7 +23,7 @@ source $ad_hdl_dir/projects/scripts/adi_board.tcl
 # LEGEND: Serial    - 0
 #         Parallel  - 1
 #
-# NOTE : This switch is a 'hardware' switch. Please reimplenent the
+# NOTE : This switch is a 'hardware' switch. Please reimplement the
 # design if the variable has been changed.
 #
 ##--------------------------------------------------------------

--- a/projects/ad7616_sdz/zcu102/Makefile
+++ b/projects/ad7616_sdz/zcu102/Makefile
@@ -1,0 +1,25 @@
+####################################################################################
+## Copyright (c) 2018 - 2021 Analog Devices, Inc.
+### SPDX short identifier: BSD-1-Clause
+## Auto-generated, do not modify!
+####################################################################################
+
+PROJECT_NAME := ad7616_sdz_zcu102
+
+M_DEPS += serial_if_constr.xdc
+M_DEPS += parallel_if_constr.xdc
+M_DEPS += ../common/ad7616_bd.tcl
+M_DEPS += ../../scripts/adi_pd.tcl
+M_DEPS += ../../common/zcu102/zcu102_system_constr.xdc
+M_DEPS += ../../common/zcu102/zcu102_system_bd.tcl
+M_DEPS += ../../../library/common/ad_iobuf.v
+
+LIB_DEPS += axi_ad7616
+LIB_DEPS += axi_clkgen
+LIB_DEPS += axi_dmac
+LIB_DEPS += axi_hdmi_tx
+LIB_DEPS += axi_spdif_tx
+LIB_DEPS += axi_sysid
+LIB_DEPS += sysid_rom
+
+include ../../scripts/project-xilinx.mk

--- a/projects/ad7616_sdz/zcu102/parallel_if_constr.xdc
+++ b/projects/ad7616_sdz/zcu102/parallel_if_constr.xdc
@@ -1,3 +1,7 @@
+###############################################################################
+## Copyright (C) 2023 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
 
 # ad7616 - Parallel mode
 # Note: The design uses an SDP to FMC interposer.

--- a/projects/ad7616_sdz/zcu102/parallel_if_constr.xdc
+++ b/projects/ad7616_sdz/zcu102/parallel_if_constr.xdc
@@ -6,34 +6,34 @@
 # ad7616 - Parallel mode
 # Note: The design uses an SDP to FMC interposer.
 
-set_property -dict {PACKAGE_PIN AH4  IOSTANDARD LVCOMOS18} [get_ports adc_db[0]]        ; ## C14  FMC1_LA10_P      IO_L15P_T2L_N4_AD11P_65
-set_property -dict {PACKAGE_PIN AF2  IOSTANDARD LVCOMOS18} [get_ports adc_db[1]]        ; ## H10  FMC1_LA04_P      IO_L21P_T3L_N4_AD8P_65
-set_property -dict {PACKAGE_PIN AE2  IOSTANDARD LVCOMOS18} [get_ports adc_db[2]]        ; ## D14  FMC1_LA09_P      IO_L24P_T3U_N10_PERSTN1_I2C_SDA_65
-set_property -dict {PACKAGE_PIN AH1  IOSTANDARD LVCOMOS18} [get_ports adc_db[3]]        ; ## G9   FMC1_LA03_P      IO_L22P_T3U_N6_DBC_AD0P_65
-set_property -dict {PACKAGE_PIN AH3  IOSTANDARD LVCOMOS18} [get_ports adc_db[4]]        ; ## D12  FMC1_LA05_N      IO_L20N_T3L_N3_AD1N_65
-set_property -dict {PACKAGE_PIN AD1  IOSTANDARD LVCOMOS18} [get_ports adc_db[5]]        ; ## H8   FMC1_LA02_N      IO_L23N_T3U_N9_65
-set_property -dict {PACKAGE_PIN AJ2  IOSTANDARD LVCOMOS18} [get_ports adc_db[6]]        ; ## C11  FMC1_LA06_N      IO_L19N_T3L_N1_DBC_AD9N_65
-set_property -dict {PACKAGE_PIN AF5  IOSTANDARD LVCOMOS18} [get_ports adc_db[7]]        ; ## G7   FMC1_LA00_CC_N   IO_L13N_T2L_N1_GC_QBC_65
-set_property -dict {PACKAGE_PIN AG3  IOSTANDARD LVCOMOS18} [get_ports adc_db[8]]        ; ## D11  FMC1_LA05_P      IO_L20P_T3L_N2_AD1P_65
-set_property -dict {PACKAGE_PIN AD2  IOSTANDARD LVCOMOS18} [get_ports adc_db[9]]        ; ## H7   FMC1_LA02_P      IO_L23P_T3U_N8_I2C_SCLK_65
-set_property -dict {PACKAGE_PIN AH2  IOSTANDARD LVCOMOS18} [get_ports adc_db[10]]       ; ## C10  FMC1_LA06_P      IO_L19P_T3L_N0_DBC_AD9P_65
-set_property -dict {PACKAGE_PIN AE5  IOSTANDARD LVCOMOS18} [get_ports adc_db[11]]       ; ## G6   FMC1_LA00_CC_P   IO_L13P_T2L_N0_GC_QBC_65
-set_property -dict {PACKAGE_PIN AJ5  IOSTANDARD LVCOMOS18} [get_ports adc_db[12]]       ; ## D9   FMC1_LA01_CC_N   IO_L16N_T2U_N7_QBC_AD3N_65
-set_property -dict {PACKAGE_PIN AF7  IOSTANDARD LVCOMOS18} [get_ports adc_db[13]]       ; ## H5   FMC1_CLK0_M2C_N  IO_L12N_T1U_N11_GC_65
-set_property -dict {PACKAGE_PIN AE7  IOSTANDARD LVCOMOS18} [get_ports adc_db[14]]       ; ## H4   FMC1_CLK0_M2C_P  IO_L12P_T1U_N10_GC_65
-set_property -dict {PACKAGE_PIN AJ6  IOSTANDARD LVCOMOS18} [get_ports adc_db[15]]       ; ## D8   FMC1_LA01_CC_P   IO_L16P_T2U_N6_QBC_AD3P_65
+set_property -dict {PACKAGE_PIN AH4  IOSTANDARD LVCMOS18} [get_ports adc_db[0]]        ; ## C14  FMC1_LA10_P      IO_L15P_T2L_N4_AD11P_65
+set_property -dict {PACKAGE_PIN AF2  IOSTANDARD LVCMOS18} [get_ports adc_db[1]]        ; ## H10  FMC1_LA04_P      IO_L21P_T3L_N4_AD8P_65
+set_property -dict {PACKAGE_PIN AE2  IOSTANDARD LVCMOS18} [get_ports adc_db[2]]        ; ## D14  FMC1_LA09_P      IO_L24P_T3U_N10_PERSTN1_I2C_SDA_65
+set_property -dict {PACKAGE_PIN AH1  IOSTANDARD LVCMOS18} [get_ports adc_db[3]]        ; ## G9   FMC1_LA03_P      IO_L22P_T3U_N6_DBC_AD0P_65
+set_property -dict {PACKAGE_PIN AH3  IOSTANDARD LVCMOS18} [get_ports adc_db[4]]        ; ## D12  FMC1_LA05_N      IO_L20N_T3L_N3_AD1N_65
+set_property -dict {PACKAGE_PIN AD1  IOSTANDARD LVCMOS18} [get_ports adc_db[5]]        ; ## H8   FMC1_LA02_N      IO_L23N_T3U_N9_65
+set_property -dict {PACKAGE_PIN AJ2  IOSTANDARD LVCMOS18} [get_ports adc_db[6]]        ; ## C11  FMC1_LA06_N      IO_L19N_T3L_N1_DBC_AD9N_65
+set_property -dict {PACKAGE_PIN AF5  IOSTANDARD LVCMOS18} [get_ports adc_db[7]]        ; ## G7   FMC1_LA00_CC_N   IO_L13N_T2L_N1_GC_QBC_65
+set_property -dict {PACKAGE_PIN AG3  IOSTANDARD LVCMOS18} [get_ports adc_db[8]]        ; ## D11  FMC1_LA05_P      IO_L20P_T3L_N2_AD1P_65
+set_property -dict {PACKAGE_PIN AD2  IOSTANDARD LVCMOS18} [get_ports adc_db[9]]        ; ## H7   FMC1_LA02_P      IO_L23P_T3U_N8_I2C_SCLK_65
+set_property -dict {PACKAGE_PIN AH2  IOSTANDARD LVCMOS18} [get_ports adc_db[10]]       ; ## C10  FMC1_LA06_P      IO_L19P_T3L_N0_DBC_AD9P_65
+set_property -dict {PACKAGE_PIN AE5  IOSTANDARD LVCMOS18} [get_ports adc_db[11]]       ; ## G6   FMC1_LA00_CC_P   IO_L13P_T2L_N0_GC_QBC_65
+set_property -dict {PACKAGE_PIN AJ5  IOSTANDARD LVCMOS18} [get_ports adc_db[12]]       ; ## D9   FMC1_LA01_CC_N   IO_L16N_T2U_N7_QBC_AD3N_65
+set_property -dict {PACKAGE_PIN AF7  IOSTANDARD LVCMOS18} [get_ports adc_db[13]]       ; ## H5   FMC1_CLK0_M2C_N  IO_L12N_T1U_N11_GC_65
+set_property -dict {PACKAGE_PIN AE7  IOSTANDARD LVCMOS18} [get_ports adc_db[14]]       ; ## H4   FMC1_CLK0_M2C_P  IO_L12P_T1U_N10_GC_65
+set_property -dict {PACKAGE_PIN AJ6  IOSTANDARD LVCMOS18} [get_ports adc_db[15]]       ; ## D8   FMC1_LA01_CC_P   IO_L16P_T2U_N6_QBC_AD3P_65
 
-set_property -dict {PACKAGE_PIN AJ1  IOSTANDARD LVCOMOS18} [get_ports adc_rd_n]         ; ## G10  FMC1_LA03_N      IO_L22N_T3U_N7_DBC_AD0N_65
-set_property -dict {PACKAGE_PIN AE1  IOSTANDARD LVCOMOS18} [get_ports adc_wr_n]         ; ## D15  FMC1_LA09_N      IO_L24N_T3U_N11_PERSTN0_65
+set_property -dict {PACKAGE_PIN AJ1  IOSTANDARD LVCMOS18} [get_ports adc_rd_n]         ; ## G10  FMC1_LA03_N      IO_L22N_T3U_N7_DBC_AD0N_65
+set_property -dict {PACKAGE_PIN AE1  IOSTANDARD LVCMOS18} [get_ports adc_wr_n]         ; ## D15  FMC1_LA09_N      IO_L24N_T3U_N11_PERSTN0_65
 
-set_property -dict {PACKAGE_PIN AH12 IOSTANDARD LVCOMOS18} [get_ports adc_cnvst]        ; ## H28  FMC1_LA24_P      IO_L2P_T0L_N2_65
-set_property -dict {PACKAGE_PIN AC11 IOSTANDARD LVCOMOS18} [get_ports adc_chsel[0]]     ; ## H26  FMC1_LA21_N      IO_L1N_T0L_N1_DBC_66
-set_property -dict {PACKAGE_PIN R12  IOSTANDARD LVCOMOS18} [get_ports adc_chsel[1]]     ; ## D27  FMC1_LA26_N      IO_L4N_T0U_N7_DBC_AD7N_67
-set_property -dict {PACKAGE_PIN AE10 IOSTANDARD LVCOMOS18} [get_ports adc_chsel[2]]     ; ## G27  FMC1_LA25_P      IO_L1P_T0L_N0_DBC_65
-set_property -dict {PACKAGE_PIN AC12 IOSTANDARD LVCOMOS18} [get_ports adc_hw_rngsel[0]] ; ## H25  FMC1_LA21_P      IO_L1P_T0L_N0_DBC_66
-set_property -dict {PACKAGE_PIN T12  IOSTANDARD LVCOMOS18} [get_ports adc_hw_rngsel[1]] ; ## D26  FMC1_LA26_P      IO_L4P_T0U_N6_DBC_AD7P_67
-set_property -dict {PACKAGE_PIN AJ4  IOSTANDARD LVCOMOS18} [get_ports adc_busy]         ; ## C15  FMC1_LA10_N      IO_L15N_T2L_N5_AD11N_65
-set_property -dict {PACKAGE_PIN U10  IOSTANDARD LVCOMOS18} [get_ports adc_seq_en]       ; ## C26  FMC1_LA27_P      IO_L3P_T0L_N4_AD15P_67
-set_property -dict {PACKAGE_PIN AG11 IOSTANDARD LVCOMOS18} [get_ports adc_reset_n]      ; ## G25  FMC1_LA22_N      IO_L4N_T0U_N7_DBC_AD7N_65
-set_property -dict {PACKAGE_PIN AF1  IOSTANDARD LVCOMOS18} [get_ports adc_cs_n]         ; ## H11  FMC1_LA04_N      IO_L21N_T3L_N5_AD8N_65
+set_property -dict {PACKAGE_PIN AH12 IOSTANDARD LVCMOS18} [get_ports adc_cnvst]        ; ## H28  FMC1_LA24_P      IO_L2P_T0L_N2_65
+set_property -dict {PACKAGE_PIN AC11 IOSTANDARD LVCMOS18} [get_ports adc_chsel[0]]     ; ## H26  FMC1_LA21_N      IO_L1N_T0L_N1_DBC_66
+set_property -dict {PACKAGE_PIN R12  IOSTANDARD LVCMOS18} [get_ports adc_chsel[1]]     ; ## D27  FMC1_LA26_N      IO_L4N_T0U_N7_DBC_AD7N_67
+set_property -dict {PACKAGE_PIN AE10 IOSTANDARD LVCMOS18} [get_ports adc_chsel[2]]     ; ## G27  FMC1_LA25_P      IO_L1P_T0L_N0_DBC_65
+set_property -dict {PACKAGE_PIN AC12 IOSTANDARD LVCMOS18} [get_ports adc_hw_rngsel[0]] ; ## H25  FMC1_LA21_P      IO_L1P_T0L_N0_DBC_66
+set_property -dict {PACKAGE_PIN T12  IOSTANDARD LVCMOS18} [get_ports adc_hw_rngsel[1]] ; ## D26  FMC1_LA26_P      IO_L4P_T0U_N6_DBC_AD7P_67
+set_property -dict {PACKAGE_PIN AJ4  IOSTANDARD LVCMOS18} [get_ports adc_busy]         ; ## C15  FMC1_LA10_N      IO_L15N_T2L_N5_AD11N_65
+set_property -dict {PACKAGE_PIN U10  IOSTANDARD LVCMOS18} [get_ports adc_seq_en]       ; ## C26  FMC1_LA27_P      IO_L3P_T0L_N4_AD15P_67
+set_property -dict {PACKAGE_PIN AG11 IOSTANDARD LVCMOS18} [get_ports adc_reset_n]      ; ## G25  FMC1_LA22_N      IO_L4N_T0U_N7_DBC_AD7N_65
+set_property -dict {PACKAGE_PIN AF1  IOSTANDARD LVCMOS18} [get_ports adc_cs_n]         ; ## H11  FMC1_LA04_N      IO_L21N_T3L_N5_AD8N_65
 

--- a/projects/ad7616_sdz/zcu102/parallel_if_constr.xdc
+++ b/projects/ad7616_sdz/zcu102/parallel_if_constr.xdc
@@ -26,7 +26,7 @@ set_property -dict {PACKAGE_PIN AJ6  IOSTANDARD LVCMOS18} [get_ports adc_db[15]]
 set_property -dict {PACKAGE_PIN AJ1  IOSTANDARD LVCMOS18} [get_ports adc_rd_n]         ; ## G10  FMC1_LA03_N      IO_L22N_T3U_N7_DBC_AD0N_65
 set_property -dict {PACKAGE_PIN AE1  IOSTANDARD LVCMOS18} [get_ports adc_wr_n]         ; ## D15  FMC1_LA09_N      IO_L24N_T3U_N11_PERSTN0_65
 
-set_property -dict {PACKAGE_PIN AH12 IOSTANDARD LVCMOS18} [get_ports adc_cnvst]        ; ## H28  FMC1_LA24_P      IO_L2P_T0L_N2_65
+set_property -dict {PACKAGE_PIN AH12 IOSTANDARD LVCMOS18} [get_ports adc_convst]       ; ## H28  FMC1_LA24_P      IO_L2P_T0L_N2_65
 set_property -dict {PACKAGE_PIN AC11 IOSTANDARD LVCMOS18} [get_ports adc_chsel[0]]     ; ## H26  FMC1_LA21_N      IO_L1N_T0L_N1_DBC_66
 set_property -dict {PACKAGE_PIN R12  IOSTANDARD LVCMOS18} [get_ports adc_chsel[1]]     ; ## D27  FMC1_LA26_N      IO_L4N_T0U_N7_DBC_AD7N_67
 set_property -dict {PACKAGE_PIN AE10 IOSTANDARD LVCMOS18} [get_ports adc_chsel[2]]     ; ## G27  FMC1_LA25_P      IO_L1P_T0L_N0_DBC_65

--- a/projects/ad7616_sdz/zcu102/parallel_if_constr.xdc
+++ b/projects/ad7616_sdz/zcu102/parallel_if_constr.xdc
@@ -1,0 +1,35 @@
+
+# ad7616 - Parallel mode
+# Note: The design uses an SDP to FMC interposer.
+
+set_property -dict {PACKAGE_PIN AH4  IOSTANDARD LVCOMOS18} [get_ports adc_db[0]]        ; ## C14  FMC1_LA10_P      IO_L15P_T2L_N4_AD11P_65
+set_property -dict {PACKAGE_PIN AF2  IOSTANDARD LVCOMOS18} [get_ports adc_db[1]]        ; ## H10  FMC1_LA04_P      IO_L21P_T3L_N4_AD8P_65
+set_property -dict {PACKAGE_PIN AE2  IOSTANDARD LVCOMOS18} [get_ports adc_db[2]]        ; ## D14  FMC1_LA09_P      IO_L24P_T3U_N10_PERSTN1_I2C_SDA_65
+set_property -dict {PACKAGE_PIN AH1  IOSTANDARD LVCOMOS18} [get_ports adc_db[3]]        ; ## G9   FMC1_LA03_P      IO_L22P_T3U_N6_DBC_AD0P_65
+set_property -dict {PACKAGE_PIN AH3  IOSTANDARD LVCOMOS18} [get_ports adc_db[4]]        ; ## D12  FMC1_LA05_N      IO_L20N_T3L_N3_AD1N_65
+set_property -dict {PACKAGE_PIN AD1  IOSTANDARD LVCOMOS18} [get_ports adc_db[5]]        ; ## H8   FMC1_LA02_N      IO_L23N_T3U_N9_65
+set_property -dict {PACKAGE_PIN AJ2  IOSTANDARD LVCOMOS18} [get_ports adc_db[6]]        ; ## C11  FMC1_LA06_N      IO_L19N_T3L_N1_DBC_AD9N_65
+set_property -dict {PACKAGE_PIN AF5  IOSTANDARD LVCOMOS18} [get_ports adc_db[7]]        ; ## G7   FMC1_LA00_CC_N   IO_L13N_T2L_N1_GC_QBC_65
+set_property -dict {PACKAGE_PIN AG3  IOSTANDARD LVCOMOS18} [get_ports adc_db[8]]        ; ## D11  FMC1_LA05_P      IO_L20P_T3L_N2_AD1P_65
+set_property -dict {PACKAGE_PIN AD2  IOSTANDARD LVCOMOS18} [get_ports adc_db[9]]        ; ## H7   FMC1_LA02_P      IO_L23P_T3U_N8_I2C_SCLK_65
+set_property -dict {PACKAGE_PIN AH2  IOSTANDARD LVCOMOS18} [get_ports adc_db[10]]       ; ## C10  FMC1_LA06_P      IO_L19P_T3L_N0_DBC_AD9P_65
+set_property -dict {PACKAGE_PIN AE5  IOSTANDARD LVCOMOS18} [get_ports adc_db[11]]       ; ## G6   FMC1_LA00_CC_P   IO_L13P_T2L_N0_GC_QBC_65
+set_property -dict {PACKAGE_PIN AJ5  IOSTANDARD LVCOMOS18} [get_ports adc_db[12]]       ; ## D9   FMC1_LA01_CC_N   IO_L16N_T2U_N7_QBC_AD3N_65
+set_property -dict {PACKAGE_PIN AF7  IOSTANDARD LVCOMOS18} [get_ports adc_db[13]]       ; ## H5   FMC1_CLK0_M2C_N  IO_L12N_T1U_N11_GC_65
+set_property -dict {PACKAGE_PIN AE7  IOSTANDARD LVCOMOS18} [get_ports adc_db[14]]       ; ## H4   FMC1_CLK0_M2C_P  IO_L12P_T1U_N10_GC_65
+set_property -dict {PACKAGE_PIN AJ6  IOSTANDARD LVCOMOS18} [get_ports adc_db[15]]       ; ## D8   FMC1_LA01_CC_P   IO_L16P_T2U_N6_QBC_AD3P_65
+
+set_property -dict {PACKAGE_PIN AJ1  IOSTANDARD LVCOMOS18} [get_ports adc_rd_n]         ; ## G10  FMC1_LA03_N      IO_L22N_T3U_N7_DBC_AD0N_65
+set_property -dict {PACKAGE_PIN AE1  IOSTANDARD LVCOMOS18} [get_ports adc_wr_n]         ; ## D15  FMC1_LA09_N      IO_L24N_T3U_N11_PERSTN0_65
+
+set_property -dict {PACKAGE_PIN AH12 IOSTANDARD LVCOMOS18} [get_ports adc_cnvst]        ; ## H28  FMC1_LA24_P      IO_L2P_T0L_N2_65
+set_property -dict {PACKAGE_PIN AC11 IOSTANDARD LVCOMOS18} [get_ports adc_chsel[0]]     ; ## H26  FMC1_LA21_N      IO_L1N_T0L_N1_DBC_66
+set_property -dict {PACKAGE_PIN R12  IOSTANDARD LVCOMOS18} [get_ports adc_chsel[1]]     ; ## D27  FMC1_LA26_N      IO_L4N_T0U_N7_DBC_AD7N_67
+set_property -dict {PACKAGE_PIN AE10 IOSTANDARD LVCOMOS18} [get_ports adc_chsel[2]]     ; ## G27  FMC1_LA25_P      IO_L1P_T0L_N0_DBC_65
+set_property -dict {PACKAGE_PIN AC12 IOSTANDARD LVCOMOS18} [get_ports adc_hw_rngsel[0]] ; ## H25  FMC1_LA21_P      IO_L1P_T0L_N0_DBC_66
+set_property -dict {PACKAGE_PIN T12  IOSTANDARD LVCOMOS18} [get_ports adc_hw_rngsel[1]] ; ## D26  FMC1_LA26_P      IO_L4P_T0U_N6_DBC_AD7P_67
+set_property -dict {PACKAGE_PIN AJ4  IOSTANDARD LVCOMOS18} [get_ports adc_busy]         ; ## C15  FMC1_LA10_N      IO_L15N_T2L_N5_AD11N_65
+set_property -dict {PACKAGE_PIN U10  IOSTANDARD LVCOMOS18} [get_ports adc_seq_en]       ; ## C26  FMC1_LA27_P      IO_L3P_T0L_N4_AD15P_67
+set_property -dict {PACKAGE_PIN AG11 IOSTANDARD LVCOMOS18} [get_ports adc_reset_n]      ; ## G25  FMC1_LA22_N      IO_L4N_T0U_N7_DBC_AD7N_65
+set_property -dict {PACKAGE_PIN AF1  IOSTANDARD LVCOMOS18} [get_ports adc_cs_n]         ; ## H11  FMC1_LA04_N      IO_L21N_T3L_N5_AD8N_65
+

--- a/projects/ad7616_sdz/zcu102/serial_if_constr.xdc
+++ b/projects/ad7616_sdz/zcu102/serial_if_constr.xdc
@@ -6,25 +6,25 @@
 # ad7616 - Serial mode
 # Note: The design uses an SDP to FMC interposer.
 
-set_property -dict {PACKAGE_PIN AJ1  IOSTANDARD LVCOMOS18} [get_ports spi_sclk]         ; ## G10  FMC1_LA03_N      IO_L22N_T3U_N7_DBC_AD0N_65
-set_property -dict {PACKAGE_PIN AH1  IOSTANDARD LVCOMOS18} [get_ports spi_sdo]          ; ## G9   FMC1_LA03_P      IO_L22P_T3U_N6_DBC_AD0P_65
-set_property -dict {PACKAGE_PIN AE5  IOSTANDARD LVCOMOS18} [get_ports spi_sdi[0]]       ; ## G6   FMC1_LA00_CC_P   IO_L13P_T2L_N0_GC_QBC_65
-set_property -dict {PACKAGE_PIN AJ5  IOSTANDARD LVCOMOS18} [get_ports spi_sdi[1]]       ; ## D9   FMC1_LA01_CC_N   IO_L16N_T2U_N7_QBC_AD3N_65
-set_property -dict {PACKAGE_PIN AF1  IOSTANDARD LVCOMOS18} [get_ports spi_cs]           ; ## H11  FMC1_LA04_N      IO_L21N_T3L_N5_AD8N_65
+set_property -dict {PACKAGE_PIN AJ1  IOSTANDARD LVCMOS18} [get_ports spi_sclk]         ; ## G10  FMC1_LA03_N      IO_L22N_T3U_N7_DBC_AD0N_65
+set_property -dict {PACKAGE_PIN AH1  IOSTANDARD LVCMOS18} [get_ports spi_sdo]          ; ## G9   FMC1_LA03_P      IO_L22P_T3U_N6_DBC_AD0P_65
+set_property -dict {PACKAGE_PIN AE5  IOSTANDARD LVCMOS18} [get_ports spi_sdi[0]]       ; ## G6   FMC1_LA00_CC_P   IO_L13P_T2L_N0_GC_QBC_65
+set_property -dict {PACKAGE_PIN AJ5  IOSTANDARD LVCMOS18} [get_ports spi_sdi[1]]       ; ## D9   FMC1_LA01_CC_N   IO_L16N_T2U_N7_QBC_AD3N_65
+set_property -dict {PACKAGE_PIN AF1  IOSTANDARD LVCMOS18} [get_ports spi_cs]           ; ## H11  FMC1_LA04_N      IO_L21N_T3L_N5_AD8N_65
 
-set_property -dict {PACKAGE_PIN AH12 IOSTANDARD LVCOMOS18} [get_ports adc_cnvst]        ; ## H28  FMC1_LA24_P      IO_L2P_T0L_N2_65
-set_property -dict {PACKAGE_PIN AC11 IOSTANDARD LVCOMOS18} [get_ports adc_chsel[0]]     ; ## H26  FMC1_LA21_N      IO_L1N_T0L_N1_DBC_66
-set_property -dict {PACKAGE_PIN R12  IOSTANDARD LVCOMOS18} [get_ports adc_chsel[1]]     ; ## D27  FMC1_LA26_N      IO_L4N_T0U_N7_DBC_AD7N_67
-set_property -dict {PACKAGE_PIN AE10 IOSTANDARD LVCOMOS18} [get_ports adc_chsel[2]]     ; ## G27  FMC1_LA25_P      IO_L1P_T0L_N0_DBC_65
-set_property -dict {PACKAGE_PIN AC12 IOSTANDARD LVCOMOS18} [get_ports adc_hw_rngsel[0]] ; ## H25  FMC1_LA21_P      IO_L1P_T0L_N0_DBC_66
-set_property -dict {PACKAGE_PIN T12  IOSTANDARD LVCOMOS18} [get_ports adc_hw_rngsel[1]] ; ## D26  FMC1_LA26_P      IO_L4P_T0U_N6_DBC_AD7P_67
-set_property -dict {PACKAGE_PIN AJ4  IOSTANDARD LVCOMOS18} [get_ports adc_busy]         ; ## C15  FMC1_LA10_N      IO_L15N_T2L_N5_AD11N_65
-set_property -dict {PACKAGE_PIN U10  IOSTANDARD LVCOMOS18} [get_ports adc_seq_en]       ; ## C26  FMC1_LA27_P      IO_L3P_T0L_N4_AD15P_67
-set_property -dict {PACKAGE_PIN AG11 IOSTANDARD LVCOMOS18} [get_ports adc_reset_n]      ; ## G25  FMC1_LA22_N      IO_L4N_T0U_N7_DBC_AD7N_65
+set_property -dict {PACKAGE_PIN AH12 IOSTANDARD LVCMOS18} [get_ports adc_cnvst]        ; ## H28  FMC1_LA24_P      IO_L2P_T0L_N2_65
+set_property -dict {PACKAGE_PIN AC11 IOSTANDARD LVCMOS18} [get_ports adc_chsel[0]]     ; ## H26  FMC1_LA21_N      IO_L1N_T0L_N1_DBC_66
+set_property -dict {PACKAGE_PIN R12  IOSTANDARD LVCMOS18} [get_ports adc_chsel[1]]     ; ## D27  FMC1_LA26_N      IO_L4N_T0U_N7_DBC_AD7N_67
+set_property -dict {PACKAGE_PIN AE10 IOSTANDARD LVCMOS18} [get_ports adc_chsel[2]]     ; ## G27  FMC1_LA25_P      IO_L1P_T0L_N0_DBC_65
+set_property -dict {PACKAGE_PIN AC12 IOSTANDARD LVCMOS18} [get_ports adc_hw_rngsel[0]] ; ## H25  FMC1_LA21_P      IO_L1P_T0L_N0_DBC_66
+set_property -dict {PACKAGE_PIN T12  IOSTANDARD LVCMOS18} [get_ports adc_hw_rngsel[1]] ; ## D26  FMC1_LA26_P      IO_L4P_T0U_N6_DBC_AD7P_67
+set_property -dict {PACKAGE_PIN AJ4  IOSTANDARD LVCMOS18} [get_ports adc_busy]         ; ## C15  FMC1_LA10_N      IO_L15N_T2L_N5_AD11N_65
+set_property -dict {PACKAGE_PIN U10  IOSTANDARD LVCMOS18} [get_ports adc_seq_en]       ; ## C26  FMC1_LA27_P      IO_L3P_T0L_N4_AD15P_67
+set_property -dict {PACKAGE_PIN AG11 IOSTANDARD LVCMOS18} [get_ports adc_reset_n]      ; ## G25  FMC1_LA22_N      IO_L4N_T0U_N7_DBC_AD7N_65
 
-set_property -dict {PACKAGE_PIN AF7  IOSTANDARD LVCOMOS18} [get_ports adc_os[0]]        ; ## H5   FMC1_CLK0_M2C_N  IO_L12N_T1U_N11_GC_65
-set_property -dict {PACKAGE_PIN AE7  IOSTANDARD LVCOMOS18} [get_ports adc_os[1]]        ; ## H4   FMC1_CLK0_M2C_P  IO_L12P_T1U_N10_GC_65
-set_property -dict {PACKAGE_PIN AJ6  IOSTANDARD LVCOMOS18} [get_ports adc_os[2]]        ; ## D8   FMC1_LA01_CC_P   IO_L16P_T2U_N6_QBC_AD3P_65
-set_property -dict {PACKAGE_PIN AE1  IOSTANDARD LVCOMOS18} [get_ports adc_burst]        ; ## D15  FMC1_LA09_N      IO_L24N_T3U_N11_PERSTN0_65
-set_property -dict {PACKAGE_PIN AD1  IOSTANDARD LVCOMOS18} [get_ports adc_crcen]        ; ## H8   FMC1_LA02_N      IO_L23N_T3U_N9_65
+set_property -dict {PACKAGE_PIN AF7  IOSTANDARD LVCMOS18} [get_ports adc_os[0]]        ; ## H5   FMC1_CLK0_M2C_N  IO_L12N_T1U_N11_GC_65
+set_property -dict {PACKAGE_PIN AE7  IOSTANDARD LVCMOS18} [get_ports adc_os[1]]        ; ## H4   FMC1_CLK0_M2C_P  IO_L12P_T1U_N10_GC_65
+set_property -dict {PACKAGE_PIN AJ6  IOSTANDARD LVCMOS18} [get_ports adc_os[2]]        ; ## D8   FMC1_LA01_CC_P   IO_L16P_T2U_N6_QBC_AD3P_65
+set_property -dict {PACKAGE_PIN AE1  IOSTANDARD LVCMOS18} [get_ports adc_burst]        ; ## D15  FMC1_LA09_N      IO_L24N_T3U_N11_PERSTN0_65
+set_property -dict {PACKAGE_PIN AD1  IOSTANDARD LVCMOS18} [get_ports adc_crcen]        ; ## H8   FMC1_LA02_N      IO_L23N_T3U_N9_65
 

--- a/projects/ad7616_sdz/zcu102/serial_if_constr.xdc
+++ b/projects/ad7616_sdz/zcu102/serial_if_constr.xdc
@@ -1,3 +1,7 @@
+###############################################################################
+## Copyright (C) 2023 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
 
 # ad7616 - Serial mode
 # Note: The design uses an SDP to FMC interposer.

--- a/projects/ad7616_sdz/zcu102/serial_if_constr.xdc
+++ b/projects/ad7616_sdz/zcu102/serial_if_constr.xdc
@@ -10,9 +10,9 @@ set_property -dict {PACKAGE_PIN AJ1  IOSTANDARD LVCMOS18} [get_ports spi_sclk]  
 set_property -dict {PACKAGE_PIN AH1  IOSTANDARD LVCMOS18} [get_ports spi_sdo]          ; ## G9   FMC1_LA03_P      IO_L22P_T3U_N6_DBC_AD0P_65
 set_property -dict {PACKAGE_PIN AE5  IOSTANDARD LVCMOS18} [get_ports spi_sdi[0]]       ; ## G6   FMC1_LA00_CC_P   IO_L13P_T2L_N0_GC_QBC_65
 set_property -dict {PACKAGE_PIN AJ5  IOSTANDARD LVCMOS18} [get_ports spi_sdi[1]]       ; ## D9   FMC1_LA01_CC_N   IO_L16N_T2U_N7_QBC_AD3N_65
-set_property -dict {PACKAGE_PIN AF1  IOSTANDARD LVCMOS18} [get_ports spi_cs]           ; ## H11  FMC1_LA04_N      IO_L21N_T3L_N5_AD8N_65
+set_property -dict {PACKAGE_PIN AF1  IOSTANDARD LVCMOS18} [get_ports spi_cs_n]         ; ## H11  FMC1_LA04_N      IO_L21N_T3L_N5_AD8N_65
 
-set_property -dict {PACKAGE_PIN AH12 IOSTANDARD LVCMOS18} [get_ports adc_cnvst]        ; ## H28  FMC1_LA24_P      IO_L2P_T0L_N2_65
+set_property -dict {PACKAGE_PIN AH12 IOSTANDARD LVCMOS18} [get_ports adc_convst]       ; ## H28  FMC1_LA24_P      IO_L2P_T0L_N2_65
 set_property -dict {PACKAGE_PIN AC11 IOSTANDARD LVCMOS18} [get_ports adc_chsel[0]]     ; ## H26  FMC1_LA21_N      IO_L1N_T0L_N1_DBC_66
 set_property -dict {PACKAGE_PIN R12  IOSTANDARD LVCMOS18} [get_ports adc_chsel[1]]     ; ## D27  FMC1_LA26_N      IO_L4N_T0U_N7_DBC_AD7N_67
 set_property -dict {PACKAGE_PIN AE10 IOSTANDARD LVCMOS18} [get_ports adc_chsel[2]]     ; ## G27  FMC1_LA25_P      IO_L1P_T0L_N0_DBC_65

--- a/projects/ad7616_sdz/zcu102/serial_if_constr.xdc
+++ b/projects/ad7616_sdz/zcu102/serial_if_constr.xdc
@@ -1,0 +1,26 @@
+
+# ad7616 - Serial mode
+# Note: The design uses an SDP to FMC interposer.
+
+set_property -dict {PACKAGE_PIN AJ1  IOSTANDARD LVCOMOS18} [get_ports spi_sclk]         ; ## G10  FMC1_LA03_N      IO_L22N_T3U_N7_DBC_AD0N_65
+set_property -dict {PACKAGE_PIN AH1  IOSTANDARD LVCOMOS18} [get_ports spi_sdo]          ; ## G9   FMC1_LA03_P      IO_L22P_T3U_N6_DBC_AD0P_65
+set_property -dict {PACKAGE_PIN AE5  IOSTANDARD LVCOMOS18} [get_ports spi_sdi[0]]       ; ## G6   FMC1_LA00_CC_P   IO_L13P_T2L_N0_GC_QBC_65
+set_property -dict {PACKAGE_PIN AJ5  IOSTANDARD LVCOMOS18} [get_ports spi_sdi[1]]       ; ## D9   FMC1_LA01_CC_N   IO_L16N_T2U_N7_QBC_AD3N_65
+set_property -dict {PACKAGE_PIN AF1  IOSTANDARD LVCOMOS18} [get_ports spi_cs]           ; ## H11  FMC1_LA04_N      IO_L21N_T3L_N5_AD8N_65
+
+set_property -dict {PACKAGE_PIN AH12 IOSTANDARD LVCOMOS18} [get_ports adc_cnvst]        ; ## H28  FMC1_LA24_P      IO_L2P_T0L_N2_65
+set_property -dict {PACKAGE_PIN AC11 IOSTANDARD LVCOMOS18} [get_ports adc_chsel[0]]     ; ## H26  FMC1_LA21_N      IO_L1N_T0L_N1_DBC_66
+set_property -dict {PACKAGE_PIN R12  IOSTANDARD LVCOMOS18} [get_ports adc_chsel[1]]     ; ## D27  FMC1_LA26_N      IO_L4N_T0U_N7_DBC_AD7N_67
+set_property -dict {PACKAGE_PIN AE10 IOSTANDARD LVCOMOS18} [get_ports adc_chsel[2]]     ; ## G27  FMC1_LA25_P      IO_L1P_T0L_N0_DBC_65
+set_property -dict {PACKAGE_PIN AC12 IOSTANDARD LVCOMOS18} [get_ports adc_hw_rngsel[0]] ; ## H25  FMC1_LA21_P      IO_L1P_T0L_N0_DBC_66
+set_property -dict {PACKAGE_PIN T12  IOSTANDARD LVCOMOS18} [get_ports adc_hw_rngsel[1]] ; ## D26  FMC1_LA26_P      IO_L4P_T0U_N6_DBC_AD7P_67
+set_property -dict {PACKAGE_PIN AJ4  IOSTANDARD LVCOMOS18} [get_ports adc_busy]         ; ## C15  FMC1_LA10_N      IO_L15N_T2L_N5_AD11N_65
+set_property -dict {PACKAGE_PIN U10  IOSTANDARD LVCOMOS18} [get_ports adc_seq_en]       ; ## C26  FMC1_LA27_P      IO_L3P_T0L_N4_AD15P_67
+set_property -dict {PACKAGE_PIN AG11 IOSTANDARD LVCOMOS18} [get_ports adc_reset_n]      ; ## G25  FMC1_LA22_N      IO_L4N_T0U_N7_DBC_AD7N_65
+
+set_property -dict {PACKAGE_PIN AF7  IOSTANDARD LVCOMOS18} [get_ports adc_os[0]]        ; ## H5   FMC1_CLK0_M2C_N  IO_L12N_T1U_N11_GC_65
+set_property -dict {PACKAGE_PIN AE7  IOSTANDARD LVCOMOS18} [get_ports adc_os[1]]        ; ## H4   FMC1_CLK0_M2C_P  IO_L12P_T1U_N10_GC_65
+set_property -dict {PACKAGE_PIN AJ6  IOSTANDARD LVCOMOS18} [get_ports adc_os[2]]        ; ## D8   FMC1_LA01_CC_P   IO_L16P_T2U_N6_QBC_AD3P_65
+set_property -dict {PACKAGE_PIN AE1  IOSTANDARD LVCOMOS18} [get_ports adc_burst]        ; ## D15  FMC1_LA09_N      IO_L24N_T3U_N11_PERSTN0_65
+set_property -dict {PACKAGE_PIN AD1  IOSTANDARD LVCOMOS18} [get_ports adc_crcen]        ; ## H8   FMC1_LA02_N      IO_L23N_T3U_N9_65
+

--- a/projects/ad7616_sdz/zcu102/system_bd.tcl
+++ b/projects/ad7616_sdz/zcu102/system_bd.tcl
@@ -1,13 +1,23 @@
-
-source $ad_hdl_dir/projects/scripts/adi_pd.tcl
+###############################################################################
+## Copyright (C) 2023 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
+#
 source $ad_hdl_dir/projects/common/zcu102/zcu102_system_bd.tcl
+source $ad_hdl_dir/projects/scripts/adi_pd.tcl
+
+set mem_init_sys_path [get_env_param ADI_PROJECT_DIR ""]mem_init_sys.txt;
 
 #system ID
 ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
-ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/$mem_init_sys_path"
 ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
 
 sysid_gen_sys_init_file
 
 source ../common/ad7616_bd.tcl
 
+# memory interconnect
+
+ad_mem_hpc1_interconnect sys_cpu_clk sys_ps8/S_AXI_HPC1
+ad_mem_hpc1_interconnect sys_cpu_clk axi_ad7616_dma/m_dest_axi

--- a/projects/ad7616_sdz/zcu102/system_bd.tcl
+++ b/projects/ad7616_sdz/zcu102/system_bd.tcl
@@ -1,0 +1,13 @@
+
+source $ad_hdl_dir/projects/scripts/adi_pd.tcl
+source $ad_hdl_dir/projects/common/zcu102/zcu102_system_bd.tcl
+
+#system ID
+ad_ip_parameter axi_sysid_0 CONFIG.ROM_ADDR_BITS 9
+ad_ip_parameter rom_sys_0 CONFIG.PATH_TO_FILE "[pwd]/mem_init_sys.txt"
+ad_ip_parameter rom_sys_0 CONFIG.ROM_ADDR_BITS 9
+
+sysid_gen_sys_init_file
+
+source ../common/ad7616_bd.tcl
+

--- a/projects/ad7616_sdz/zcu102/system_project.tcl
+++ b/projects/ad7616_sdz/zcu102/system_project.tcl
@@ -1,3 +1,7 @@
+###############################################################################
+## Copyright (C) 2023 Analog Devices, Inc. All rights reserved.
+### SPDX short identifier: ADIBSD
+###############################################################################
 
 source ../../../scripts/adi_env.tcl
 source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl

--- a/projects/ad7616_sdz/zcu102/system_project.tcl
+++ b/projects/ad7616_sdz/zcu102/system_project.tcl
@@ -1,0 +1,56 @@
+
+source ../../../scripts/adi_env.tcl
+source $ad_hdl_dir/projects/scripts/adi_project_xilinx.tcl
+source $ad_hdl_dir/projects/scripts/adi_board.tcl
+
+##--------------------------------------------------------------
+# IMPORTANT: Set AD7616 operation and interface mode
+#
+# The get_env_param procedure retrieves parameter value from the environment if exists,
+# other case returns the default value specified in its second parameter field.
+#
+#   How to use over-writable parameters from the environment:
+#
+#    e.g.
+#      make SI_OR_PI=0
+#
+#    SI_OR_PI  - Defines the interface type (serial OR parallel)
+#
+# LEGEND: Serial    - 0
+#         Parallel  - 1
+#
+# NOTE : This switch is a 'hardware' switch. Please reimplement the
+# design if the variable has been changed.
+#
+##--------------------------------------------------------------
+
+if {[info exists ::env(SI_OR_PI)]} {
+  set S_SI_OR_PI [get_env_param SI_OR_PI 0]
+} elseif {![info exists SI_OR_PI]} {
+  set S_SI_OR_PI 0
+}
+
+adi_project ad7616_sdz_zcu102 0 [list \
+  SI_OR_PI  $S_SI_OR_PI \
+]
+
+adi_project_files ad7616_sdz_zcu102 [list \
+  "$ad_hdl_dir/library/common/ad_iobuf.v" \
+  "$ad_hdl_dir/projects/common/zcu102/zcu102_system_constr.xdc"]
+
+switch $S_SI_OR_PI {
+  0 {
+    adi_project_files ad7616_sdz_zcu102 [list \
+      "system_top_si.v" \
+      "serial_if_constr.xdc"
+    ]
+  }
+  1 {
+    adi_project_files ad7616_sdz_zcu102 [list \
+      "system_top_pi.v" \
+      "parallel_if_constr.xdc"
+    ]
+  }
+}
+
+adi_project_run ad7616_sdz_zcu102

--- a/projects/ad7616_sdz/zcu102/system_top_pi.v
+++ b/projects/ad7616_sdz/zcu102/system_top_pi.v
@@ -1,0 +1,69 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright 2014 - 2017 (c) Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL (Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsibilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository (LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository (LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/master/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+
+`timescale 1ns/100ps
+
+module system_top (
+
+  input   [12:0]  gpio_bd_i,
+  output  [ 7:0]  gpio_bd_o
+);
+
+  // internal signals
+  wire    [94:0]  gpio_i;
+  wire    [94:0]  gpio_o;
+
+  assign gpio_bd_o = gpio_o[7:0];
+
+  assign gpio_i[94:21] = gpio_o[94:21];
+  assign gpio_i[20: 8] = gpio_bd_i;
+  assign gpio_i[ 7: 0] = gpio_o[ 7: 0];
+
+  // instantiations
+  system_wrapper i_system_wrapper (
+    .gpio_i (gpio_i),
+    .gpio_o (gpio_o),
+    .gpio_t (),
+
+    .spi0_csn (1'b1),
+    .spi0_miso (1'b0),
+    .spi0_mosi (),
+    .spi0_sclk (),
+    .spi1_csn (1'b1),
+    .spi1_miso (1'b0),
+    .spi1_mosi (),
+    .spi1_sclk ());
+
+endmodule

--- a/projects/ad7616_sdz/zcu102/system_top_pi.v
+++ b/projects/ad7616_sdz/zcu102/system_top_pi.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright 2014 - 2017 (c) Analog Devices, Inc. All rights reserved.
+// Copyright 2023 (c) Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are

--- a/projects/ad7616_sdz/zcu102/system_top_pi.v
+++ b/projects/ad7616_sdz/zcu102/system_top_pi.v
@@ -87,7 +87,7 @@ module system_top (
              adc_seq_en,         // 37
              adc_chsel}));       // 35:33
 
-  assign gpio_i[63:44] = gpio_o[63:44];
+  assign gpio_i[94:44] = gpio_o[94:44];
   assign gpio_i[40:38] = gpio_o[40:38];
   assign gpio_i[36] = gpio_o[36];
 
@@ -101,19 +101,11 @@ module system_top (
     end
   endgenerate
 
-  ad_iobuf #(
-    .DATA_WIDTH(15)
-  ) i_iobuf_gpio (
-    .dio_t(gpio_t[14:0]),
-    .dio_i(gpio_o[14:0]),
-    .dio_o(gpio_i[14:0]),
-    .dio_p(gpio_bd));
-
   system_wrapper i_system_wrapper (
     .gpio_i (gpio_i),
     .gpio_o (gpio_o),
-    .gpio_t (),
-
+    .gpio_t (gpio_t),
+    
     .spi0_csn (1'b1),
     .spi0_miso (1'b0),
     .spi0_mosi (),

--- a/projects/ad7616_sdz/zcu102/system_top_pi.v
+++ b/projects/ad7616_sdz/zcu102/system_top_pi.v
@@ -56,11 +56,11 @@ module system_top (
 
   // internal signals
 
-  assign gpio_bd_o = gpio_o[7:0];
+  //assign gpio_bd_o = gpio_o[7:0];
 
-  assign gpio_i[94:21] = gpio_o[94:21];
-  assign gpio_i[20: 8] = gpio_bd_i;
-  assign gpio_i[ 7: 0] = gpio_o[ 7: 0];
+  //assign gpio_i[94:21] = gpio_o[94:21];
+  //assign gpio_i[20: 8] = gpio_bd_i;
+  //assign gpio_i[ 7: 0] = gpio_o[ 7: 0];
 
   // internal signals
 

--- a/projects/ad7616_sdz/zcu102/system_top_pi.v
+++ b/projects/ad7616_sdz/zcu102/system_top_pi.v
@@ -38,12 +38,23 @@
 module system_top (
 
   input   [12:0]  gpio_bd_i,
-  output  [ 7:0]  gpio_bd_o
+  output  [ 7:0]  gpio_bd_o,
+  inout   [31:0]  gpio_bd,
+
+  inout   [15:0]  adc_db,
+  output          adc_rd_n,
+  output          adc_wr_n,
+
+  output          adc_cs_n,
+  output          adc_reset_n,
+  output          adc_convst,
+  input           adc_busy,
+  output          adc_seq_en,
+  output  [ 1:0]  adc_hw_rngsel,
+  output  [ 2:0]  adc_chsel
 );
 
   // internal signals
-  wire    [94:0]  gpio_i;
-  wire    [94:0]  gpio_o;
 
   assign gpio_bd_o = gpio_o[7:0];
 
@@ -51,7 +62,53 @@ module system_top (
   assign gpio_i[20: 8] = gpio_bd_i;
   assign gpio_i[ 7: 0] = gpio_o[ 7: 0];
 
+  // internal signals
+
+  wire    [94:0]  gpio_i;
+  wire    [94:0]  gpio_o;
+  wire    [94:0]  gpio_t;
+
+  wire            adc_db_t;
+  wire    [15:0]  adc_db_o;
+  wire    [15:0]  adc_db_i;
+
+  genvar i;
+
   // instantiations
+
+  ad_iobuf #(
+    .DATA_WIDTH(7)
+  ) i_iobuf_adc_cntrl (
+    .dio_t ({gpio_t[43:41], gpio_t[37], gpio_t[35:33]}),
+    .dio_i ({gpio_o[43:41], gpio_o[37], gpio_o[35:33]}),
+    .dio_o ({gpio_i[43:41], gpio_i[37], gpio_i[35:33]}),
+    .dio_p ({adc_reset_n,        // 43
+             adc_hw_rngsel,      // 42:41
+             adc_seq_en,         // 37
+             adc_chsel}));       // 35:33
+
+  assign gpio_i[63:44] = gpio_o[63:44];
+  assign gpio_i[40:38] = gpio_o[40:38];
+  assign gpio_i[36] = gpio_o[36];
+
+  generate
+    for (i = 0; i < 16; i = i + 1) begin: adc_db_io
+      ad_iobuf i_iobuf_adc_db (
+        .dio_t(adc_db_t),
+        .dio_i(adc_db_o[i]),
+        .dio_o(adc_db_i[i]),
+        .dio_p(adc_db[i]));
+    end
+  endgenerate
+
+  ad_iobuf #(
+    .DATA_WIDTH(15)
+  ) i_iobuf_gpio (
+    .dio_t(gpio_t[14:0]),
+    .dio_i(gpio_o[14:0]),
+    .dio_o(gpio_i[14:0]),
+    .dio_p(gpio_bd));
+
   system_wrapper i_system_wrapper (
     .gpio_i (gpio_i),
     .gpio_o (gpio_o),
@@ -64,6 +121,14 @@ module system_top (
     .spi1_csn (1'b1),
     .spi1_miso (1'b0),
     .spi1_mosi (),
-    .spi1_sclk ());
+    .spi1_sclk (),
+    .rx_cnvst (adc_convst),
+    .rx_cs_n (adc_cs_n),
+    .rx_busy (adc_busy),
+    .rx_db_o (adc_db_o),
+    .rx_db_i (adc_db_i),
+    .rx_db_t (adc_db_t),
+    .rx_rd_n (adc_rd_n),
+    .rx_wr_n (adc_wr_n));
 
 endmodule

--- a/projects/ad7616_sdz/zcu102/system_top_si.v
+++ b/projects/ad7616_sdz/zcu102/system_top_si.v
@@ -37,7 +37,7 @@
 module system_top (
 
   input   [12:0]  gpio_bd_i,
-  output  [ 7:0]  gpio_bd_o
+  output  [ 7:0]  gpio_bd_o,
 
   output                  spi_sclk,
   output                  spi_sdo,

--- a/projects/ad7616_sdz/zcu102/system_top_si.v
+++ b/projects/ad7616_sdz/zcu102/system_top_si.v
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // ***************************************************************************
-// Copyright 2014 - 2017 (c) Analog Devices, Inc. All rights reserved.
+// Copyright 2023 (c) Analog Devices, Inc. All rights reserved.
 //
 // In this HDL repository, there are many different and unique modules, consisting
 // of various HDL (Verilog or VHDL) components. The individual modules are

--- a/projects/ad7616_sdz/zcu102/system_top_si.v
+++ b/projects/ad7616_sdz/zcu102/system_top_si.v
@@ -1,0 +1,95 @@
+// ***************************************************************************
+// ***************************************************************************
+// Copyright 2014 - 2017 (c) Analog Devices, Inc. All rights reserved.
+//
+// In this HDL repository, there are many different and unique modules, consisting
+// of various HDL (Verilog or VHDL) components. The individual modules are
+// developed independently, and may be accompanied by separate and unique license
+// terms.
+//
+// The user should read each of these license terms, and understand the
+// freedoms and responsibilities that he or she has by using this source/core.
+//
+// This core is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.
+//
+// Redistribution and use of source or resulting binaries, with or without modification
+// of this file, are permitted under one of the following two license terms:
+//
+//   1. The GNU General Public License version 2 as published by the
+//      Free Software Foundation, which can be found in the top level directory
+//      of this repository (LICENSE_GPL2), and also online at:
+//      <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+//
+// OR
+//
+//   2. An ADI specific BSD license, which can be found in the top level directory
+//      of this repository (LICENSE_ADIBSD), and also on-line at:
+//      https://github.com/analogdevicesinc/hdl/blob/master/LICENSE_ADIBSD
+//      This will allow to generate bit files and not release the source code,
+//      as long as it attaches to an ADI device.
+//
+// ***************************************************************************
+// ***************************************************************************
+`timescale 1ns/100ps
+
+module system_top (
+
+  input   [12:0]  gpio_bd_i,
+  output  [ 7:0]  gpio_bd_o
+
+  output                  spi_sclk,
+  output                  spi_sdo,
+  input       [ 1:0]      spi_sdi,
+  output                  spi_cs_n,
+
+  output                  adc_reset_n,
+  output                  adc_convst,
+  input                   adc_busy,
+  output                  adc_seq_en,
+  output      [ 1:0]      adc_hw_rngsel,
+  output      [ 2:0]      adc_chsel,
+  output                  adc_crcen,
+  output                  adc_burst,
+  output      [ 2:0]      adc_os
+);
+
+  // internal signals
+  wire    [94:0]  gpio_i;
+  wire    [94:0]  gpio_o;
+  wire    [94:0]  gpio_t;
+
+  assign gpio_bd_o = gpio_o[7:0];
+
+  assign gpio_i[94:44] = gpio_o[94:44];
+  assign gpio_i[20: 8] = gpio_bd_i;
+  assign gpio_i[ 7: 0] = gpio_o[ 7: 0];
+
+    ad_iobuf #(
+    .DATA_WIDTH(12)
+  ) i_iobuf_adc_cntrl (
+    .dio_t (gpio_t[43:32]),
+    .dio_i (gpio_o[43:32]),
+    .dio_o (gpio_i[43:32]),
+    .dio_p ({adc_reset_n,        // 43
+             adc_hw_rngsel,      // 42:41
+             adc_os,             // 40:38
+             adc_seq_en,         // 37
+             adc_burst,          // 36
+             adc_chsel,          // 35:33
+             adc_crcen}));       // 32
+
+  // instantiations
+  system_wrapper i_system_wrapper (
+    .gpio_i (gpio_i),
+    .gpio_o (gpio_o),
+    .gpio_t (gpio_t),
+    .rx_sclk (spi_sclk),
+    .rx_sdo (spi_sdo),
+    .rx_sdi (spi_sdi),
+    .rx_cnvst (adc_convst),
+    .rx_cs_n (spi_cs_n),
+    .rx_busy (adc_busy));
+
+endmodule

--- a/projects/ad7616_sdz/zed/system_bd.tcl
+++ b/projects/ad7616_sdz/zed/system_bd.tcl
@@ -17,3 +17,7 @@ sysid_gen_sys_init_file
 
 source ../common/ad7616_bd.tcl
 
+# memory interconnect
+
+ad_mem_hp1_interconnect sys_cpu_clk sys_ps7/S_AXI_HPC1
+ad_mem_hp1_interconnect sys_cpu_clk axi_ad7616_dma/m_dest_axi

--- a/projects/ad7616_sdz/zed/system_project.tcl
+++ b/projects/ad7616_sdz/zed/system_project.tcl
@@ -23,7 +23,7 @@ source $ad_hdl_dir/projects/scripts/adi_board.tcl
 # LEGEND: Serial    - 0
 #         Parallel  - 1
 #
-# NOTE : This switch is a 'hardware' switch. Please reimplenent the
+# NOTE : This switch is a 'hardware' switch. Please reimplement the
 # design if the variable has been changed.
 #
 ##--------------------------------------------------------------


### PR DESCRIPTION
## PR Description

Bring-up for Xilinx ZCU102 with the EVAL-AD7616SDZ, connected via SDP-I-FMC to FMC1 connector.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the code style guidelines
- [x] I have performed a self-review of changes
- [x] I have compiled all hdl projects and libraries affected by this PR
- [x] I have tested in hardware affected projects, at least on relevant boards
- [x] I have commented my code, at least hard-to-understand parts
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe files, Copyright etc)
- [ ] I have not introduced new Warnings/Critical Warnings on compilation
- [ ] I have added new hdl testbenches or updated existing ones
